### PR TITLE
add socks5 proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ Binary file will be built at ./bin/hget, you can copy to /usr/bin or /usr/local/
 ## Usage
 
 ```
-hget [Url] [-n parallel] [-skip-tls false] //to download url, with n connections, and not skip tls certificate
+hget [Url] [-n parallel] [-skip-tls false] [-proxy proxy_server]://to download url, with n connections, and not skip tls certificate
 hget tasks //get interrupted tasks
 hget resume [TaskName | URL] //to resume task
+hget -proxy "127.0.0.1:12345" https://releases.ubuntu.com/20.04.1/ubuntu-20.04.1-desktop-amd64.iso # to download using socks5 proxy
+hget -proxy "http://sample-proxy.com:8080" https://releases.ubuntu.com/20.04.1/ubuntu-20.04.1-desktop-amd64.iso # to download using http proxy
 ```
 
 To interrupt any on-downloading process, just ctrl-c or ctrl-d at the middle of the download, hget will safely save your data and you will be able to resume later

--- a/http.go
+++ b/http.go
@@ -136,14 +136,24 @@ func ProxyAwareHttpClient(socks5_proxy string) *http.Client {
 	// setup a http client
 	httpTransport := &http.Transport{}
 	httpClient := &http.Client{Transport: httpTransport}
-
+	dialer := nil
 	// set our socks5 as the dialer
 	if len(socks5_proxy) > 0 {
-		// create a socks5 dialer
-		dialer, err := proxy.SOCKS5("tcp", socks5_proxy, nil, proxy.Direct)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "can't connect to the proxy: ", err)
-			return httpClient
+		if strings.HasPrefix(socks5_proxy, "http"){
+			proxyUrl, err := url.Parse(proxyServer)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "invalid proxy: ", err)
+			}
+			dialer, err = proxy.FromURL(proxyUrl, proxy.Direct)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "can't connect to the proxy: ", err)
+			}
+		}else{
+			// create a socks5 dialer
+			dialer, err := proxy.SOCKS5("tcp", socks5_proxy, nil, proxy.Direct)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "can't connect to the proxy: ", err)
+			}
 		}
 		httpTransport.Dial = dialer.Dial
 	}

--- a/http.go
+++ b/http.go
@@ -140,9 +140,9 @@ func ProxyAwareHttpClient(socks5_proxy string) *http.Client {
 	// set our socks5 as the dialer
 	if len(socks5_proxy) > 0 {
 		// create a socks5 dialer
-		dialer, err := proxy.SOCKS5("tcp", d.proxy, nil, proxy.Direct)
+		dialer, err := proxy.SOCKS5("tcp", socks5_proxy, nil, proxy.Direct)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "can't connect to the proxy:", err)
+			fmt.Fprintln(os.Stderr, "can't connect to the proxy: ", err)
 			return httpClient
 		}
 		httpTransport.Dial = dialer.Dial

--- a/http.go
+++ b/http.go
@@ -136,21 +136,23 @@ func ProxyAwareHttpClient(socks5_proxy string) *http.Client {
 	// setup a http client
 	httpTransport := &http.Transport{}
 	httpClient := &http.Client{Transport: httpTransport}
+	var dialer proxy.Dialer
+	dialer = proxy.Direct
 	
-	// set our socks5 as the dialer
 	if len(socks5_proxy) > 0 {
 		if strings.HasPrefix(socks5_proxy, "http"){
 			proxyUrl, err := stdurl.Parse(socks5_proxy)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "invalid proxy: ", err)
 			}
+			// create a http dialer
 			dialer, err = proxy.FromURL(proxyUrl, proxy.Direct)
 			if err == nil {
 				httpTransport.Dial = dialer.Dial
 			}
 		}else{
 			// create a socks5 dialer
-			dialer, err := proxy.SOCKS5("tcp", socks5_proxy, nil, proxy.Direct)
+			dialer, err = proxy.SOCKS5("tcp", socks5_proxy, nil, proxy.Direct)
 			if err == nil {
 				httpTransport.Dial = dialer.Dial
 			}

--- a/http.go
+++ b/http.go
@@ -140,7 +140,7 @@ func ProxyAwareHttpClient(socks5_proxy string) *http.Client {
 	dialer = proxy.Direct
 	
 	if len(socks5_proxy) > 0 {
-		if strings.HasPrefix(socks5_proxy, "http"){
+		if strings.HasPrefix(socks5_proxy, "http") {
 			proxyUrl, err := stdurl.Parse(socks5_proxy)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "invalid proxy: ", err)
@@ -150,9 +150,9 @@ func ProxyAwareHttpClient(socks5_proxy string) *http.Client {
 			if err == nil {
 				httpTransport.Dial = dialer.Dial
 			}
-		}else{
+		} else {
 			// create a socks5 dialer
-			dialer, err = proxy.SOCKS5("tcp", socks5_proxy, nil, proxy.Direct)
+			dialer, err := proxy.SOCKS5("tcp", socks5_proxy, nil, proxy.Direct)
 			if err == nil {
 				httpTransport.Dial = dialer.Dial
 			}

--- a/http.go
+++ b/http.go
@@ -136,26 +136,26 @@ func ProxyAwareHttpClient(socks5_proxy string) *http.Client {
 	// setup a http client
 	httpTransport := &http.Transport{}
 	httpClient := &http.Client{Transport: httpTransport}
-	dialer := nil
+	
 	// set our socks5 as the dialer
 	if len(socks5_proxy) > 0 {
 		if strings.HasPrefix(socks5_proxy, "http"){
-			proxyUrl, err := url.Parse(proxyServer)
+			proxyUrl, err := stdurl.Parse(socks5_proxy)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "invalid proxy: ", err)
 			}
 			dialer, err = proxy.FromURL(proxyUrl, proxy.Direct)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, "can't connect to the proxy: ", err)
+			if err == nil {
+				httpTransport.Dial = dialer.Dial
 			}
 		}else{
 			// create a socks5 dialer
 			dialer, err := proxy.SOCKS5("tcp", socks5_proxy, nil, proxy.Direct)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, "can't connect to the proxy: ", err)
+			if err == nil {
+				httpTransport.Dial = dialer.Dial
 			}
 		}
-		httpTransport.Dial = dialer.Dial
+		
 	}
 	return httpClient
 }

--- a/main.go
+++ b/main.go
@@ -13,9 +13,11 @@ var displayProgress = true
 
 func main() {
 	var err error
+	var proxy string
 
-	conn    := flag.Int("n", runtime.NumCPU(), "connection")
+	conn := flag.Int("n", runtime.NumCPU(), "connection")
 	skiptls := flag.Bool("skip-tls", true, "skip verify certificate for https")
+	flag.StringVar(&proxy, "proxy", "", "socks5 proxy for downloading")
 
 	flag.Parse()
 	args := flag.Args()
@@ -47,7 +49,7 @@ func main() {
 
 		state, err := Resume(task)
 		FatalCheck(err)
-		Execute(state.Url, state, *conn, *skiptls)
+		Execute(state.Url, state, *conn, *skiptls, proxy)
 		return
 	} else {
 		if ExistDir(FolderOf(command)) {
@@ -55,11 +57,11 @@ func main() {
 			err := os.RemoveAll(FolderOf(command))
 			FatalCheck(err)
 		}
-		Execute(command, nil, *conn, *skiptls)
+		Execute(command, nil, *conn, *skiptls, proxy)
 	}
 }
 
-func Execute(url string, state *State, conn int, skiptls bool) {
+func Execute(url string, state *State, conn int, skiptls bool, proxy string) {
 	//otherwise is hget <URL> command
 	var err error
 
@@ -84,7 +86,7 @@ func Execute(url string, state *State, conn int, skiptls bool) {
 
 	var downloader *HttpDownloader
 	if state == nil {
-		downloader = NewHttpDownloader(url, conn, skiptls)
+		downloader = NewHttpDownloader(url, conn, skiptls, proxy)
 	} else {
 		downloader = &HttpDownloader{url: state.Url, file: filepath.Base(state.Url), par: int64(len(state.Parts)), parts: state.Parts, resumable: true}
 	}
@@ -132,7 +134,7 @@ func Execute(url string, state *State, conn int, skiptls bool) {
 
 func usage() {
 	Printf(`Usage:
-hget [URL] [-n connection] [-skip-tls true]
+hget [URL] [-n connection] [-skip-tls true] [-proxy socks5_proxy]
 hget tasks
 hget resume [TaskName]
 `)

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 
 	conn := flag.Int("n", runtime.NumCPU(), "connection")
 	skiptls := flag.Bool("skip-tls", true, "skip verify certificate for https")
-	flag.StringVar(&proxy, "proxy", "", "socks5 proxy for downloading")
+	flag.StringVar(&proxy, "proxy", "", "proxy for downloading, ex \n\t-proxy '127.0.0.1:12345' for socks5 proxy\n\t-proxy 'http://proxy.com:8080' for http proxy")
 
 	flag.Parse()
 	args := flag.Args()
@@ -134,7 +134,7 @@ func Execute(url string, state *State, conn int, skiptls bool, proxy string) {
 
 func usage() {
 	Printf(`Usage:
-hget [URL] [-n connection] [-skip-tls true] [-proxy socks5_proxy]
+hget [URL] [-n connection] [-skip-tls true] [-proxy proxy_address]
 hget tasks
 hget resume [TaskName]
 `)


### PR DESCRIPTION
we can have socks5 proxy support

usage:
```bash
hget -proxy "127.0.0.1:12345" https://releases.ubuntu.com/20.04.1/ubuntu-20.04.1-desktop-amd64.iso
```


we can also use the env and forget about the flag, something like this:
```go
proxyServer, isSet := os.LookupEnv("HTTP_PROXY")
if isSet {
	proxyUrl, err := url.Parse(proxyServer)
	if err == nil {
                dialer, err = proxy.FromURL(proxyUrl, proxy.Direct)
	}else if strings.HasPrefix("socks5://"){
                socksProxy := strings.Replace(proxyUrl, "socks5://", "", -1)
                dialer, err := proxy.SOCKS5("tcp", socksProxy, nil, proxy.Direct)
        }
}
```