### PR TITLE
refactor: update URL parsing and file extraction logic

### DIFF
--- a/http.go
+++ b/http.go
@@ -95,9 +95,7 @@ func NewHTTPDownloader(url string, par int, skipTLS bool, proxyServer string, bw
 		Printf("Download target size: %.1f GB\n", sizeInMb/1024)
 	}
 
-	parsed, err = stdurl.Parse(url)
-	FatalCheck(err)
-	file := filepath.Base(strings.TrimRight(parsed.Path, "/\\"))
+	file := TaskFromURL(url)
 
 	ret := new(HTTPDownloader)
 	ret.rate = 0
@@ -131,9 +129,7 @@ func partCalculate(par int64, len int64, url string) []Part {
 			to = len
 		}
 
-		parsed, err := stdurl.Parse(url)
-		FatalCheck(err)
-		file := filepath.Base(strings.TrimRight(parsed.Path, "/\\"))
+		file := TaskFromURL(url)
 
 		folder := FolderOf(url)
 		if err := MkdirIfNotExist(folder); err != nil {

--- a/http.go
+++ b/http.go
@@ -95,7 +95,10 @@ func NewHTTPDownloader(url string, par int, skipTLS bool, proxyServer string, bw
 		Printf("Download target size: %.1f GB\n", sizeInMb/1024)
 	}
 
-	file := filepath.Base(url)
+	parsed, err = stdurl.Parse(url)
+	FatalCheck(err)
+	file := filepath.Base(strings.TrimRight(parsed.Path, "/\\"))
+
 	ret := new(HTTPDownloader)
 	ret.rate = 0
 	bandwidthLimit, err := units.ParseStrictBytes(bwLimit)
@@ -128,7 +131,10 @@ func partCalculate(par int64, len int64, url string) []Part {
 			to = len
 		}
 
-		file := filepath.Base(url)
+		parsed, err := stdurl.Parse(url)
+		FatalCheck(err)
+		file := filepath.Base(strings.TrimRight(parsed.Path, "/\\"))
+
 		folder := FolderOf(url)
 		if err := MkdirIfNotExist(folder); err != nil {
 			Errorf("%v", err)

--- a/util.go
+++ b/util.go
@@ -55,11 +55,9 @@ func DisplayProgressBar() bool {
 func FolderOf(urlStr string) string {
 	safePath := filepath.Join(os.Getenv("HOME"), dataFolder)
 
-	parsedURL, err := url.Parse(urlStr)
-	FatalCheck(err)
 	// Extract the last path from the URL, excluding parameters.
 	// eg: URL_ADDRESS.com/path/to/file?param=value -> file
-	cleanPath := filepath.Base(strings.TrimRight(parsedURL.Path, "/\\"))
+	cleanPath := TaskFromURL(urlStr)
 
 	fullQualifyPath, err := filepath.Abs(filepath.Join(os.Getenv("HOME"), dataFolder, cleanPath))
 	FatalCheck(err)

--- a/util_test.go
+++ b/util_test.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"testing"
 	"path/filepath"
+	"testing"
 )
 
-func TestFilterIpV4(t *testing.T){
+func TestFilterIpV4(t *testing.T) {
 }
 
 func TestFolderOfPanic1(t *testing.T) {
@@ -28,6 +28,14 @@ func TestFolderOfPanic2(t *testing.T) {
 
 func TestFolderOfNormal(t *testing.T) {
 	url := "http://foo.bar/file"
+	u := FolderOf(url)
+	if filepath.Base(u) != "file" {
+		t.Fatalf("url of return incorrect value")
+	}
+}
+
+func TestFolderWithoutParams(t *testing.T) {
+	url := "http://foo.bar/file?param=value"
 	u := FolderOf(url)
 	if filepath.Base(u) != "file" {
 		t.Fatalf("url of return incorrect value")


### PR DESCRIPTION
Fix URL filename extraction for downloads

This PR addresses an issue with URL filename extraction where query parameters and trailing slashes were incorrectly included in the downloaded filename. The changes:

1. Properly parse URLs using the standard url package
2. Extract only the path component from URLs
3. Remove trailing slashes from filenames
4. Apply consistent filename extraction logic across all parts of the application

These changes ensure that downloaded files have clean, appropriate filenames without query parameters or trailing slashes, improving the user experience and preventing potential issues with unusual filenames, like filename too lang error.